### PR TITLE
Add link to slack, replacing twitter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,8 +18,8 @@ google_analytics: "UA-119875762-1"
 social:
   - title: github
     url: https://github.com/socialgorithm
-  - title: twitter
-    url: https://twitter.com/Socialgorithm_
+  - title: slack
+    url: https://socialgorithm-slack.herokuapp.com
 
 # Build settings
 markdown: kramdown

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -27,6 +27,11 @@
                     <a class="page-scroll" href="#contact">Contact</a>
                 </li>
                 <li>
+                    <a href="https://socialgorithm-slack.herokuapp.com">
+                        <i class="fa fa-slack"></i> Slack Community
+                    </a>
+                </li>
+                <li>
                     <a href="https://github.com/socialgorithm">
                         <i class="fa fa-github"></i> Github
                     </a>


### PR DESCRIPTION
Figured we don't really use the twitter much and are giving Slack another go.